### PR TITLE
Alteracao no nome do module e README com instrucoes para uso do projeto

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: Build
 
 on:
   push:
-    branches: [ v1 ]
+    branches: [ main ]
   pull_request:
-    branches: [ v1 ]
+    branches: [ main ]
   workflow_dispatch:
 
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, tip]
+        go-version: [1.13.x, 1.14.x, 1.15.x, 1.16.x, 1.17.x, 1.18.x, 1.19.x, 1.20.x, 1.21.x, tip]
         full-tests: [false]
         include:
           - go-version: 1.21.x

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# httpmock [![Build Status](https://github.com/jarcoal/httpmock/workflows/Build/badge.svg?branch=v1)](https://github.com/jarcoal/httpmock/actions?query=workflow%3ABuild) [![Coverage Status](https://coveralls.io/repos/github/jarcoal/httpmock/badge.svg?branch=v1)](https://coveralls.io/github/jarcoal/httpmock?branch=v1) [![GoDoc](https://godoc.org/github.com/jarcoal/httpmock?status.svg)](https://godoc.org/github.com/jarcoal/httpmock) [![Version](https://img.shields.io/github/tag/jarcoal/httpmock.svg)](https://github.com/jarcoal/httpmock/releases) [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go/#testing)
+# httpmock [![Build Status](https://github.com/eucatur/httpmock/workflows/Build/badge.svg?branch=v1)](https://github.com/eucatur/httpmock/actions?query=workflow%3ABuild) [![Coverage Status](https://coveralls.io/repos/github/jarcoal/httpmock/badge.svg?branch=v1)](https://coveralls.io/github/jarcoal/httpmock?branch=v1) [![GoDoc](https://godoc.org/github.com/eucatur/httpmock?status.svg)](https://godoc.org/github.com/eucatur/httpmock) [![Version](https://img.shields.io/github/tag/jarcoal/httpmock.svg)](https://github.com/eucatur/httpmock/releases) [![Mentioned in Awesome Go](https://awesome.re/mentioned-badge.svg)](https://github.com/avelino/awesome-go/#testing)
 
 Easy mocking of http responses from external resources.
 
@@ -10,12 +10,12 @@ Currently supports Go 1.13 to 1.21 and is regularly tested against tip.
 
 In your go files, simply use:
 ```go
-import "github.com/jarcoal/httpmock"
+import "github.com/eucatur/httpmock"
 ```
 
 Then next `go mod tidy` or `go test` invocation will automatically
 populate your `go.mod` with the latest httpmock release, now
-[![Version](https://img.shields.io/github/tag/jarcoal/httpmock.svg)](https://github.com/jarcoal/httpmock/releases).
+[![Version](https://img.shields.io/github/tag/jarcoal/httpmock.svg)](https://github.com/eucatur/httpmock/releases).
 
 
 ## Usage
@@ -129,7 +129,7 @@ in the same order, the first match stops the search.
 import (
   "testing"
 
-  "github.com/jarcoal/httpmock"
+  "github.com/eucatur/httpmock"
   "github.com/maxatome/go-testdeep/helpers/tdsuite"
   "github.com/maxatome/go-testdeep/td"
 )
@@ -172,7 +172,7 @@ func (s *MySuite) TestArticles(assert, require *td.T) {
 
 import (
   // ...
-  "github.com/jarcoal/httpmock"
+  "github.com/eucatur/httpmock"
 )
 // ...
 var _ = BeforeSuite(func() {
@@ -194,7 +194,7 @@ var _ = AfterSuite(func() {
 
 import (
   // ...
-  "github.com/jarcoal/httpmock"
+  "github.com/eucatur/httpmock"
 )
 
 var _ = Describe("Articles", func() {
@@ -213,7 +213,7 @@ var _ = Describe("Articles", func() {
 
 import (
   // ...
-  "github.com/jarcoal/httpmock"
+  "github.com/eucatur/httpmock"
   "github.com/go-resty/resty"
 )
 // ...
@@ -236,7 +236,7 @@ var _ = AfterSuite(func() {
 
 import (
   // ...
-  "github.com/jarcoal/httpmock"
+  "github.com/eucatur/httpmock"
   "github.com/go-resty/resty"
 )
 

--- a/VOCE_TEM_QUE_LER.md
+++ b/VOCE_TEM_QUE_LER.md
@@ -1,0 +1,12 @@
+## Introdução
+Esse projeto é um fork de https://github.com/eucatur/httpmock. \
+Trouxemos para github da Eucatur para termos liberdade de alterações, correções e adaptações rápidas e caso necessário facilitar nas contribuições com o projeto original.
+
+## Instruções quanto às Branchs
+Esse projeto contém 2 Branchs principais
+* `v1:` Até o presente momento(2023-12-15 17:15:00) é a branch oficial do [projeto principal](https://github.com/eucatur/httpmock). Então caso haja alguma contribuição ao [projeto principal](https://github.com/eucatur/httpmock) tenha total conciência que está branch esteja com fork sincronizado e as as implementações parte dessa Branch para que a contribuição seja enviada ao respositório do [projeto principal](https://github.com/eucatur/httpmock).
+* `main:` Essa é a branch principal para utilização dentro do contexto da Eucatur para que os projetos possam sempre usar as dependências partindo deste respositório
+  * Então a instrução para manter esta branch(`main`) atualizada é que puxe uma branch de atualização a partir da branch do [projeto principal](https://github.com/eucatur/httpmock) e abra um PR para branch `main` que com isso a atualização será analisada pelos demais para avaliar o impacto da atualização.
+  * Caso necesside contribuir e a contribuição reflita para branch `main`, basta seguir com a branch de contribuição a partir da branch principal(`v1` - atualmente 2023-12-15 17:23:00) do [projeto principal](https://github.com/eucatur/httpmock) realizar os trâmites de aprovação da contribuição com o repositório principal. A contribuição sendo aprovada pelos responsáveis do repositório principal, sincronize o repositório da Eucatur, ou seja, este respositório. Repositório entando sincronizado com [projeto principal](https://github.com/eucatur/httpmock) sincronize com a branch `main` para que reflita a contribuição para os contextos da Eucatur.
+      * ### LEMBRE-SE! a branch `main` está com os pacotes apontando para namespace eucatur, ou seja, os modules apontandos para github.com/eucatur/httpmock
+        * Então, ao alinhar a [branch principal do projeto](https://github.com/eucatur/httpmock) com a branch do contexto eucatur(`main`) certifique-se que os pacotes continuam apontando para os módulos **github.com/eucatur/httpmock**

--- a/env_test.go
+++ b/env_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock"
+	"github.com/eucatur/httpmock"
 )
 
 const envVarName = "GONOMOCKS"

--- a/export_test.go
+++ b/export_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"sync/atomic"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 var (

--- a/file_test.go
+++ b/file_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock"
+	"github.com/eucatur/httpmock"
 )
 
 var _ json.Marshaler = httpmock.File("test.json")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
-module github.com/jarcoal/httpmock
+module github.com/eucatur/httpmock
 
-go 1.18
+go 1.21
 
 require github.com/maxatome/go-testdeep v1.12.0
 

--- a/internal/error.go
+++ b/internal/error.go
@@ -5,11 +5,9 @@ import (
 	"fmt"
 )
 
-// NoResponderFound is returned when no responders are found for a
+// ErrNoResponderFound is returned when no responders are found for a
 // given HTTP method and URL.
-//
-//lint:ignore ST1012 revive
-var NoResponderFound = errors.New("no responder found") // nolint: ST1012 revive
+var ErrNoResponderFound = errors.New("no responder found") // nolint: ST1012 revive
 
 // ErrorNoResponderFoundMistake encapsulates a NoResponderFound
 // error probably due to a user error on the method or URL path.
@@ -23,19 +21,19 @@ var _ error = (*ErrorNoResponderFoundMistake)(nil)
 
 // Unwrap implements the interface needed by errors.Unwrap.
 func (e *ErrorNoResponderFoundMistake) Unwrap() error {
-	return NoResponderFound
+	return ErrNoResponderFound
 }
 
 // Error implements error interface.
 func (e *ErrorNoResponderFoundMistake) Error() string {
 	if e.Kind == "matcher" {
 		return fmt.Sprintf("%s despite %s",
-			NoResponderFound,
+			ErrNoResponderFound,
 			e.Suggested,
 		)
 	}
 	return fmt.Sprintf("%[1]s for %[2]s %[3]q, but one matches %[2]s %[4]q",
-		NoResponderFound,
+		ErrNoResponderFound,
 		e.Kind,
 		e.Orig,
 		e.Suggested,

--- a/internal/error.go
+++ b/internal/error.go
@@ -7,7 +7,9 @@ import (
 
 // NoResponderFound is returned when no responders are found for a
 // given HTTP method and URL.
-var NoResponderFound = errors.New("no responder found") // nolint: revive
+//
+//lint:ignore ST1012 revive
+var NoResponderFound = errors.New("no responder found") // nolint: ST1012 revive
 
 // ErrorNoResponderFoundMistake encapsulates a NoResponderFound
 // error probably due to a user error on the method or URL path.

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 func TestErrorNoResponderFoundMistake(t *testing.T) {

--- a/internal/error_test.go
+++ b/internal/error_test.go
@@ -15,7 +15,7 @@ func TestErrorNoResponderFoundMistake(t *testing.T) {
 		Suggested: "BINGO",
 	}
 	td.Cmp(t, e.Error(), `no responder found for method "pipo", but one matches method "BINGO"`)
-	td.Cmp(t, e.Unwrap(), internal.NoResponderFound)
+	td.Cmp(t, e.Unwrap(), internal.ErrNoResponderFound)
 
 	e = &internal.ErrorNoResponderFoundMistake{
 		Kind:      "matcher",
@@ -23,5 +23,5 @@ func TestErrorNoResponderFoundMistake(t *testing.T) {
 		Suggested: "BINGO",
 	}
 	td.Cmp(t, e.Error(), `no responder found despite BINGO`)
-	td.Cmp(t, e.Unwrap(), internal.NoResponderFound)
+	td.Cmp(t, e.Unwrap(), internal.ErrNoResponderFound)
 }

--- a/internal/route_key_test.go
+++ b/internal/route_key_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 func TestRouteKey(t *testing.T) {

--- a/internal/stack_tracer_test.go
+++ b/internal/stack_tracer_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 func TestStackTracer(t *testing.T) {

--- a/internal/submatches_test.go
+++ b/internal/submatches_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 func TestSubmatches(t *testing.T) {

--- a/match.go
+++ b/match.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"sync/atomic"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 var ignorePackages = map[string]bool{}

--- a/match_test.go
+++ b/match_test.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	"github.com/jarcoal/httpmock"
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock"
+	"github.com/eucatur/httpmock/internal"
 )
 
 func TestMatcherFunc_AndOr(t *testing.T) {

--- a/race_test.go
+++ b/race_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	. "github.com/jarcoal/httpmock"
+	. "github.com/eucatur/httpmock"
 )
 
 func TestActivateNonDefaultRace(t *testing.T) {

--- a/response.go
+++ b/response.go
@@ -15,7 +15,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 // fromThenKeyType is used by Then().
@@ -62,7 +62,7 @@ func (r Responder) times(name string, n int, fn ...func(...any)) Responder {
 //
 //	import (
 //	  "testing"
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	)
 //	...
 //	func TestMyApp(t *testing.T) {
@@ -84,7 +84,7 @@ func (r Responder) Times(n int, fn ...func(...any)) Responder {
 //
 //	import (
 //	  "testing"
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	)
 //	...
 //	func TestMyApp(t *testing.T) {
@@ -105,7 +105,7 @@ func (r Responder) Once(fn ...func(...any)) Responder {
 //
 //	import (
 //	  "testing"
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	)
 //	...
 //	func TestMyApp(t *testing.T) {
@@ -129,7 +129,7 @@ func (r Responder) Trace(fn func(...any)) Responder {
 //	import (
 //	  "testing"
 //	  "time"
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	)
 //	...
 //	func TestMyApp(t *testing.T) {
@@ -411,7 +411,7 @@ func ResponderFromResponse(resp *http.Response) Responder {
 // dump the stack trace to localize the origin of the call.
 //
 //	import (
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	  "testing"
 //	)
 //	...
@@ -482,7 +482,7 @@ func NewErrorResponder(err error) Responder {
 //
 //	import (
 //	  "testing"
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	)
 //	...
 //	func TestMyApp(t *testing.T) {
@@ -494,8 +494,8 @@ func NewErrorResponder(err error) Responder {
 // Will abort the current test and print something like:
 //
 //	transport_test.go:735: Called from net/http.Get()
-//	      at /go/src/github.com/jarcoal/httpmock/transport_test.go:714
-//	    github.com/jarcoal/httpmock.TestCheckStackTracer()
+//	      at /go/src/github.com/eucatur/httpmock/transport_test.go:714
+//	    github.com/eucatur/httpmock.TestCheckStackTracer()
 //	      at /go/src/testing/testing.go:865
 //	    testing.tRunner()
 //	      at /go/src/runtime/asm_amd64.s:1337

--- a/response_test.go
+++ b/response_test.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	. "github.com/jarcoal/httpmock"
-	"github.com/jarcoal/httpmock/internal"
+	. "github.com/eucatur/httpmock"
+	"github.com/eucatur/httpmock/internal"
 )
 
 func TestResponderFromResponse(t *testing.T) {

--- a/transport.go
+++ b/transport.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/jarcoal/httpmock/internal"
+	"github.com/eucatur/httpmock/internal"
 )
 
 const regexpPrefix = "=~"
@@ -989,8 +989,8 @@ func sortedQuery(m url.Values) string {
 // will abort the current test and print something like:
 //
 //	transport_test.go:735: Called from net/http.Get()
-//	      at /go/src/github.com/jarcoal/httpmock/transport_test.go:714
-//	    github.com/jarcoal/httpmock.TestCheckStackTracer()
+//	      at /go/src/github.com/eucatur/httpmock/transport_test.go:714
+//	    github.com/eucatur/httpmock.TestCheckStackTracer()
 //	      at /go/src/testing/testing.go:865
 //	    testing.tRunner()
 //	      at /go/src/runtime/asm_amd64.s:1337
@@ -1606,7 +1606,7 @@ func RegisterResponderWithQuery(method, path string, query any, responder Respon
 //
 //	import (
 //	  "testing"
-//	  "github.com/jarcoal/httpmock"
+//	  "github.com/eucatur/httpmock"
 //	)
 //	...
 //	func TestMyApp(t *testing.T) {
@@ -1618,8 +1618,8 @@ func RegisterResponderWithQuery(method, path string, query any, responder Respon
 // will abort the current test and print something like:
 //
 //	transport_test.go:735: Called from net/http.Get()
-//	      at /go/src/github.com/jarcoal/httpmock/transport_test.go:714
-//	    github.com/jarcoal/httpmock.TestCheckStackTracer()
+//	      at /go/src/github.com/eucatur/httpmock/transport_test.go:714
+//	    github.com/eucatur/httpmock.TestCheckStackTracer()
 //	      at /go/src/testing/testing.go:865
 //	    testing.tRunner()
 //	      at /go/src/runtime/asm_amd64.s:1337

--- a/transport.go
+++ b/transport.go
@@ -20,7 +20,7 @@ const regexpPrefix = "=~"
 
 // NoResponderFound is returned when no responders are found for a
 // given HTTP method and URL.
-var NoResponderFound = internal.NoResponderFound
+var NoResponderFound = internal.ErrNoResponderFound
 
 var stdMethods = map[string]bool{
 	"CONNECT": true, // Section 9.9

--- a/transport_test.go
+++ b/transport_test.go
@@ -17,8 +17,8 @@ import (
 
 	"github.com/maxatome/go-testdeep/td"
 
-	. "github.com/jarcoal/httpmock"
-	"github.com/jarcoal/httpmock/internal"
+	. "github.com/eucatur/httpmock"
+	"github.com/eucatur/httpmock/internal"
 )
 
 const testURL = "http://www.example.com/"


### PR DESCRIPTION
* refactor[projeto]: alteracoes no nome do module, apontamentos alterados para o contexto eucatur
* docs[VOCE_TEM_QUE_LER]: README com instrucoes de como usar as branchs do projeto para manter a compatibilidade